### PR TITLE
Gui crash fix

### DIFF
--- a/src/utils/camera.py
+++ b/src/utils/camera.py
@@ -10,7 +10,7 @@ class CameraManager:
     def __init__(self, cap: cv2.VideoCapture, app: QtWidgets.QApplication) -> None:
         self.cap = cap
         self.app = app
-        self.fps = self.cap.get(cv2.CAP_PROP_FPS)  # Used for frame processing
+        self.fps = self.cap.get(cv2.CAP_PROP_FPS) if self.cap else None  # Used for frame processing
 
     def stop(self):
         if self.cap.isOpened():
@@ -38,11 +38,55 @@ class CameraFeed(QtWidgets.QLabel):
         self.setMinimumSize(320, 240)  # Adjust size as needed
         self.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
 
+        # Main message label
+        self.message_label = QtWidgets.QLabel("Initializing your camera. \n This may take a few seconds.", self)
+        self.message_label.setStyleSheet("color: white; font-size: 16px;")
+        self.message_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+
+        # Dots label
+        self.dots_label = QtWidgets.QLabel("", self)
+        self.dots_label.setStyleSheet("color: white; font-size: 32px;")
+        self.dots_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+
+        # Layout to position labels
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(self.message_label)
+        layout.addWidget(self.dots_label)
+        self.setLayout(layout)
+
+        self.show_initial_message()
+
+    def show_initial_message(self):
+        """Display a black box with an initializing message and start the animation."""
+        self.setStyleSheet("background-color: black;")
+        
+        # Timer for animated text
+        self.animation_timer = QtCore.QTimer(self)
+        self.animation_timer.timeout.connect(self.update_initial_message)
+        self.animation_timer.start(500)  # Update every 500ms
+
+    def update_initial_message(self):
+        """Animate the dots below the initial message."""
+        current_text = self.dots_label.text()
+        if current_text.endswith("..."):
+            self.dots_label.setText("")
+        else:
+            self.dots_label.setText(current_text + ".")
+
     def update_camera_feed(self, frame):
+        # Stop the animation once the camera feed is ready
+        self.animation_timer.stop()
+
+        # Clear the initial message
+        self.setStyleSheet("")
+        self.message_label.hide()
+        self.dots_label.hide()
+
         # Convert frame to QImage
         height, width, channel = frame.shape
         bytes_per_line = 3 * width
         q_image = QtGui.QImage(frame.data, width, height, bytes_per_line, QtGui.QImage.Format.Format_RGB888)
+        
         # Convert to QPixmap and scale to fit the label
         pixmap = QtGui.QPixmap.fromImage(q_image)
         scaled_pixmap = pixmap.scaled(self.size(), QtCore.Qt.AspectRatioMode.KeepAspectRatio)

--- a/src/utils/screen.py
+++ b/src/utils/screen.py
@@ -49,6 +49,7 @@ class ControlWindow(QtWidgets.QWidget):
             )
         self.layout.addWidget(self.camera_selection_widget)
         self.camera_selection_widget.camera_combo.currentIndexChanged.connect(self.on_camera_selection_changed) # Connect camera selection change signal
+        self.camera_selection_widget.start()  # Initially disable camera selection
 
         # Blink Timer setting layout
         self.blink_timer_widget = BlinkTimerWidget(
@@ -193,6 +194,7 @@ class ControlWindow(QtWidgets.QWidget):
         selected_quantile = quantile_values[value - 1]
         self.blink_detector.module.calibrator.quantile = selected_quantile #affects detector as it is passed by reference
 
+    
     
 class BlurWindow(QtWidgets.QWidget):
     """

--- a/src/utils/screen.py
+++ b/src/utils/screen.py
@@ -87,6 +87,7 @@ class ControlWindow(QtWidgets.QWidget):
             stop_callback=self.stop_application
             )
         self.layout.addLayout(self.button_layout)
+        self.button_layout.upon_start() #Initially disable buttons until camera is live
 
         self.setLayout(self.layout)
         self.update_styles()

--- a/src/utils/widgets.py
+++ b/src/utils/widgets.py
@@ -275,6 +275,11 @@ class ButtonLayout(QtWidgets.QHBoxLayout):
         self.stop_button.clicked.connect(stop_callback)
         self.addWidget(self.stop_button)
 
+    def upon_start(self):
+        """Set the buttons to a disabled state with a grey appearance (until camera is loaded)."""
+        self.start_button.setEnabled(False)
+        self.stop_button.setEnabled(False)
+    
     def start(self):
         self.start_button.setEnabled(False)
         self.start_button.setText("Detecting your Blinks...")
@@ -282,6 +287,7 @@ class ButtonLayout(QtWidgets.QHBoxLayout):
 
     def stop(self):
         self.start_button.setEnabled(True)
+        self.stop_button.setEnabled(True)
         self.start_button.setText("Start")
         self.start_button.setStyleSheet("""
             QPushButton {


### PR DESCRIPTION
This fixes the GUI freeze for camera initializations that take longer than usual. Instead, the user sees a waiting screen in the camera feed display. During the beginning initialization Start/Stop buttons as well as the camera selection widget are disabled.